### PR TITLE
Issues 56 and 57: Support executing PAL.ps1 from different directory and allow PS session log retention

### DIFF
--- a/PAL2/PALWizard/bin/Debug/PAL.ps1
+++ b/PAL2/PALWizard/bin/Debug/PAL.ps1
@@ -936,9 +936,9 @@ Function InheritFromThresholdFiles
     ForEach ($XmlInheritance in $XmlThresholdFile.SelectNodes('//INHERITANCE'))
     {
         $inheritedXml = $($XmlInheritance.FilePath)
-		if(-not ([string]::IsNullOrWhiteSpace($inheritedXml))){
-			$inheritedXml = Resolve-Path "$PSScriptRoot\$inheritedXml"
-		}
+        If(-not ([string]::IsNullOrWhiteSpace($inheritedXml))){
+            $inheritedXml = Resolve-Path "$PSScriptRoot\$inheritedXml"
+        }
         If ($(Test-FileExists $inheritedXml) -eq $True)
         {
             $XmlInherited = [xml] (Get-Content $inheritedXml -Encoding UTF8)

--- a/PAL2/PALWizard/bin/Debug/PAL.ps1
+++ b/PAL2/PALWizard/bin/Debug/PAL.ps1
@@ -1,7 +1,26 @@
 ﻿#requires -Version 2.0
-param($Log='SamplePerfmonLog.blg',$ThresholdFile="QuickSystemOverview.xml",$AnalysisInterval='AUTO',$IsOutputHtml=$True,$IsOutputXml=$False,$HtmlOutputFileName="[LogFileName]_PAL_[DateTimeStamp].htm",$XmlOutputFileName="[LogFileName]_PAL_[DateTimeStamp].xml",$OutputDir="[My Documents]\PAL Reports",$AllCounterStats=$False,$BeginTime=$null,$EndTime=$null,[System.Int32] $NumberOfThreads=1,$IsLowPriority=$False,$DisplayReport=$True)
+param(
+	$Log='SamplePerfmonLog.blg',
+	$ThresholdFile="QuickSystemOverview.xml",
+	$AnalysisInterval='AUTO',
+	$IsOutputHtml=$True,
+	$IsOutputXml=$False,
+	$HtmlOutputFileName="[LogFileName]_PAL_[DateTimeStamp].htm",
+	$XmlOutputFileName="[LogFileName]_PAL_[DateTimeStamp].xml",
+	$OutputDir="[My Documents]\PAL Reports",
+	$AllCounterStats=$False,
+	$BeginTime=$null,
+	$EndTime=$null,
+	[System.Int32] $NumberOfThreads=1,
+	$IsLowPriority=$False,
+	$DisplayReport=$True,
+	$ClearLog=$True
+)
 Set-StrictMode -Version 2
-cls
+if($ClearLog){
+	cls
+	$Error.Clear()
+}
 #//
 #// PAL v2.8
 #// Written by Clint Huffman (clinthuffman@hotmail.com)
@@ -12,7 +31,6 @@ cls
 #// Global changable variables
 #///////////////////////////////
 
-$Error.Clear()
 $Version = '2.8.1'
 $AutoAnalysisIntervalNumberOfTimeSlices = 30
 
@@ -533,13 +551,14 @@ Function ProcessArgs
 Function StartDebugLogFile
 {
     param($sDirectoryPath, $iAttempt)
+    $timestamp = $((Get-Date).ToFileTimeUtc())
 	If ($iAttempt -eq 0) 
 	{
-        $sFilePath = $sDirectoryPath + "\PAL.log"
+        $sFilePath = $sDirectoryPath + "\PAL-$timestamp.log"
     }
 	Else
 	{
-        $sFilePath = $sDirectoryPath + "\PAL" + $iAttempt + ".log"
+        $sFilePath = $sDirectoryPath + "\PAL-$timestamp-$iAttempt.log"
     }
 	$erroractionpreference = "SilentlyContinue"
     
@@ -916,9 +935,13 @@ Function InheritFromThresholdFiles
     #// Inherit from other threshold files.
     ForEach ($XmlInheritance in $XmlThresholdFile.SelectNodes('//INHERITANCE'))
     {
-        If ($(Test-FileExists $XmlInheritance.FilePath) -eq $True)
+        $inheritedXml = $($XmlInheritance.FilePath)
+		if(-not ([string]::IsNullOrWhiteSpace($inheritedXml))){
+			$inheritedXml = Resolve-Path "$PSScriptRoot\$inheritedXml"
+		}
+        If ($(Test-FileExists $inheritedXml) -eq $True)
         {
-            $XmlInherited = [xml] (Get-Content $XmlInheritance.FilePath -Encoding UTF8)
+            $XmlInherited = [xml] (Get-Content $inheritedXml -Encoding UTF8)
             ForEach ($XmlInheritedAnalysisNode in $XmlInherited.selectNodes('//ANALYSIS'))
             {
                 $bFound = $False            
@@ -957,11 +980,14 @@ Function InheritFromThresholdFiles
                 }
             }
             
-    		If ($global:oXml.ThresholdFilePathLoadHistory.Contains($XmlInheritance.FilePath) -eq $False)
+    		If ($global:oXml.ThresholdFilePathLoadHistory.Contains($inheritedXml) -eq $False)
     		{
-    			InheritFromThresholdFiles $XmlInheritance.FilePath
+    			InheritFromThresholdFiles $inheritedXml
     		}
         }
+        elseif(-not [string]::IsNullOrWhiteSpace($inheritedXml)){
+			Write-Warning "Unable to locate inherited file $inheritedXml..."
+		}
     }
 }
 
@@ -1845,10 +1871,12 @@ Function GetRawDataSourceData($XmlDataSource)
 {
     [bool] $IsAtLeastOneCounterInstanceFound = $False
     $htCounterIndexes = @()
+    
+    $counterLangPath = "$PSScriptRoot\CounterLang.xml"
 
-    if ((Test-Path -Path 'CounterLang.xml') -eq $True)
+    if ((Test-Path -Path $counterLangPath) -eq $True)
     {
-        $xmlCounterLang = [xml] (Get-Content -Path 'CounterLang.xml' -Encoding UTF8)
+        $xmlCounterLang = [xml] (Get-Content -Path $counterLangPath -Encoding UTF8)
     }    
 
     $oCtr = CounterPathToObject -sCounterPath $XmlDataSource.EXPRESSIONPATH
@@ -5453,7 +5481,7 @@ $global:iOverallCompletion = 0
 Write-Progress -activity 'Overall progress...' -status 'Progress: 0%... SetThreadPriority' -percentcomplete 0 -id 1
     SetThreadPriority
     InitializeGlobalVariables
-    #StartDebugLogFile $global:oPal.Session.UserTempDirectory 0
+    StartDebugLogFile $global:oPal.Session.UserTempDirectory 0
     ShowMainHeader
     GlobalizationCheck
 UpdateOverallProgress -Status 'ProcessArgs'
@@ -5499,4 +5527,4 @@ UpdateOverallProgress -Status 'Saving the XML report'
     SaveXmlReport
 Write-Progress -activity 'Overall progress...' -Completed -id 1 -Status 'Progress: 100%'
     OpenHtmlReport -HtmlOutputFileName $($global:oPal.ArgsProcessed.HtmlOutputFileName)
-    #StopDebugLogFile
+    StopDebugLogFile

--- a/PAL2/PALWizard/bin/Debug/Readme.txt
+++ b/PAL2/PALWizard/bin/Debug/Readme.txt
@@ -31,6 +31,8 @@ Execute the the PAL icon in your Start Programs menu or run the PAL.ps1 script f
 
 -DisplayReport
 
+-ClearLog: (Optional) Indicates whether PAL should clear the PowerShell log before executing.
+
 -AllCounterStats: (Optional) System.Boolean This is a new feature in PAL v2.0 which tells PAL to chart all performance counters found in the log. *Warning:* This can be resource intensive. If omitted, False is assumed - meaning PAL will only chart and analyze counters found in the PAL threshold file specified in the ThresholdFile argument.
 
 -OutputDir: (Optional) System.String This is the directory path of the directory location create the output of the tool.


### PR DESCRIPTION
Reintroduced capabilities added originally in PR#12, but lost during the v2.8.1 release.

Added support for calculating relative paths to various threshold files based on the location of PAL.ps1 instead of the PowerShell session's current working directory. This allows for PAL to be executed from anywhere without issue, which is beneficial for larger automation.

Added support for NOT clearing the PowerShell session at the beginning of execution, so a bigger automation script doesn't lose everything prior to PAL starting.

Re-enabled the debug logging to the user's temp directory, but added a timestamp to the file name, so that each execution doesn't wipe out the previous log.

Resolves #56 
Resolves #57 